### PR TITLE
Go cleanup - 2

### DIFF
--- a/controllers/dashboard.go
+++ b/controllers/dashboard.go
@@ -39,7 +39,7 @@ func traceFiles(path string) []*trace.Session {
 	return res
 }
 
-func (c *ApiController) ListSessions() {
+func (c *APIController) ListSessions() {
 	path := filepath.Join(util.CacheDir, "mouselog")
 	res := []*trace.SessionJson{}
 	for _, ss := range traceFiles(path) {
@@ -50,7 +50,7 @@ func (c *ApiController) ListSessions() {
 	c.ServeJSON()
 }
 
-func (c *ApiController) ListTraces() {
+func (c *APIController) ListTraces() {
 	perPage := util.ParseInt(c.Input().Get("perPage"))
 	page := util.ParseInt(c.Input().Get("page"))
 	session, isNew := Session(c.Input().Get("fileId"))
@@ -72,7 +72,7 @@ func (c *ApiController) ListTraces() {
 	c.ServeJSON()
 }
 
-func (c *ApiController) GetTrace() {
+func (c *APIController) GetTrace() {
 	session, isNew := Session(c.Input().Get("fileId"))
 	if isNew {
 		trackNewSession(session)
@@ -82,7 +82,7 @@ func (c *ApiController) GetTrace() {
 	c.ServeJSON()
 }
 
-func (c *ApiController) UploadFile() {
+func (c *APIController) UploadFile() {
 	fmt.Printf("[SessionId %s]\n", c.StartSession().SessionID())
 
 	fileCount := 0

--- a/controllers/dashboard.go
+++ b/controllers/dashboard.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"fmt"
-	"path/filepath"
 	"strconv"
 
 	"github.com/microsoft/mouselog/detect"
@@ -37,17 +36,6 @@ func traceFiles(path string) []*trace.Session {
 	}
 
 	return res
-}
-
-func (c *APIController) ListSessions() {
-	path := filepath.Join(util.CacheDir, "mouselog")
-	res := []*trace.SessionJson{}
-	for _, ss := range traceFiles(path) {
-		res = append(res, ss.ToJson())
-	}
-
-	c.Data["json"] = res
-	c.ServeJSON()
 }
 
 func (c *APIController) ListTraces() {

--- a/controllers/dashboard.go
+++ b/controllers/dashboard.go
@@ -20,8 +20,8 @@ func traceFiles(path string) []*trace.Session {
 	res := []*trace.Session{}
 
 	if util.FileExist(path) {
-		for _, fileId := range util.ListFileIds(path) {
-			if s, isNew := Session(fileId); isNew {
+		for _, fileID := range util.ListFileIds(path) {
+			if s, isNew := Session(fileID); isNew {
 				trackNewSession(s)
 			}
 		}

--- a/controllers/impression.go
+++ b/controllers/impression.go
@@ -2,17 +2,17 @@ package controllers
 
 import "github.com/microsoft/mouselog/trace"
 
-func (c *ApiController) GetImpressions() {
+func (c *APIController) GetImpressions() {
 	c.Data["json"] = trace.GetImpressions(c.Input().Get("sessionId"))
 	c.ServeJSON()
 }
 
-func (c *ApiController) GetImpression() {
+func (c *APIController) GetImpression() {
 	c.Data["json"] = trace.GetImpression(c.Input().Get("id"))
 	c.ServeJSON()
 }
 
-func (c *ApiController) DeleteImpression() {
+func (c *APIController) DeleteImpression() {
 	c.Data["json"] = trace.DeleteImpression(c.Input().Get("id"))
 	c.ServeJSON()
 }

--- a/controllers/rule.go
+++ b/controllers/rule.go
@@ -2,7 +2,7 @@ package controllers
 
 import "github.com/microsoft/mouselog/detect"
 
-func (c *ApiController) ListRules() {
+func (c *APIController) ListRules() {
 	c.Data["json"] = detect.GetRuleListJson()
 	c.ServeJSON()
 }

--- a/controllers/session.go
+++ b/controllers/session.go
@@ -2,17 +2,17 @@ package controllers
 
 import "github.com/microsoft/mouselog/trace"
 
-func (c *ApiController) GetSessions() {
+func (c *APIController) GetSessions() {
 	c.Data["json"] = trace.GetSessions(c.Input().Get("websiteId"))
 	c.ServeJSON()
 }
 
-func (c *ApiController) GetSession() {
+func (c *APIController) GetSession() {
 	c.Data["json"] = trace.GetSession(c.Input().Get("id"), c.Input().Get("websiteId"))
 	c.ServeJSON()
 }
 
-func (c *ApiController) DeleteSession() {
+func (c *APIController) DeleteSession() {
 	c.Data["json"] = trace.DeleteSession(c.Input().Get("id"), c.Input().Get("websiteId"))
 	c.ServeJSON()
 }

--- a/controllers/session.go
+++ b/controllers/session.go
@@ -1,18 +1,65 @@
 package controllers
 
-import "github.com/microsoft/mouselog/trace"
+import (
+	"path/filepath"
 
-func (c *APIController) GetSessions() {
-	c.Data["json"] = trace.GetSessions(c.Input().Get("websiteId"))
+	"github.com/astaxie/beego"
+	"github.com/microsoft/mouselog/trace"
+	"github.com/microsoft/mouselog/util"
+)
+
+var sessions map[string]*trace.Session
+
+func init() {
+	sessions = map[string]*trace.Session{}
+}
+
+type SessionController struct {
+	beego.Controller
+}
+
+func (c *SessionController) DeleteSession() {
+	c.Data["json"] = trace.DeleteSession(c.Input().Get("id"), c.Input().Get("websiteId"))
 	c.ServeJSON()
 }
 
-func (c *APIController) GetSession() {
+func (c *SessionController) Session() {
 	c.Data["json"] = trace.GetSession(c.Input().Get("id"), c.Input().Get("websiteId"))
 	c.ServeJSON()
 }
 
-func (c *APIController) DeleteSession() {
-	c.Data["json"] = trace.DeleteSession(c.Input().Get("id"), c.Input().Get("websiteId"))
+func (c *SessionController) SessionID() {
+	sessionID := c.StartSession().SessionID()
+
+	trace.AddSession(sessionID, c.Input().Get("websiteId"), c.Ctx.Input.UserAgent(), c.Ctx.Input.IP())
+
+	c.Data["json"] = sessionID
 	c.ServeJSON()
+}
+
+func (c *SessionController) Sessions() {
+	c.Data["json"] = trace.GetSessions(c.Input().Get("websiteId"))
+	c.ServeJSON()
+}
+
+func (c *SessionController) ListSessions() {
+	path := filepath.Join(util.CacheDir, "mouselog")
+	res := []*trace.SessionJson{}
+	for _, ss := range traceFiles(path) {
+		res = append(res, ss.ToJson())
+	}
+
+	c.Data["json"] = res
+	c.ServeJSON()
+}
+
+// Session either returns an already existing session or creates and returns a new one.
+// If a new session has been created, the returned boolean will be true.
+func Session(sessionID string) (*trace.Session, bool) {
+	if val, ok := sessions[sessionID]; ok {
+		return val, false
+	}
+
+	sessions[sessionID] = trace.NewSession(sessionID)
+	return sessions[sessionID], true
 }

--- a/controllers/test.go
+++ b/controllers/test.go
@@ -37,7 +37,7 @@ type response struct {
 	Data   interface{} `json:"data"`
 }
 
-func (c *APIController) GetSessionID() {
+func (c *APIController) SessionID() {
 	sessionID := c.StartSession().SessionID()
 
 	trace.AddSession(sessionID, c.Input().Get("websiteId"), c.Ctx.Input.UserAgent(), c.Ctx.Input.IP())

--- a/controllers/test.go
+++ b/controllers/test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/microsoft/mouselog/trace"
 )
 
-type ApiController struct {
+type APIController struct {
 	beego.Controller
 }
 
@@ -22,13 +22,13 @@ func init() {
 
 // Session either returns an already existing session or creates and returns a new one.
 // If a new session has been created, the returned boolean will be true.
-func Session(sessionId string) (*trace.Session, bool) {
-	if val, ok := sessions[sessionId]; ok {
+func Session(sessionID string) (*trace.Session, bool) {
+	if val, ok := sessions[sessionID]; ok {
 		return val, false
 	}
 
-	sessions[sessionId] = trace.NewSession(sessionId)
-	return sessions[sessionId], true
+	sessions[sessionID] = trace.NewSession(sessionID)
+	return sessions[sessionID], true
 }
 
 type Response struct {
@@ -37,23 +37,23 @@ type Response struct {
 	Data   interface{} `json:"data"`
 }
 
-func (c *ApiController) GetSessionId() {
-	sessionId := c.StartSession().SessionID()
+func (c *APIController) GetSessionID() {
+	sessionID := c.StartSession().SessionID()
 
-	trace.AddSession(sessionId, c.Input().Get("websiteId"), c.Ctx.Input.UserAgent(), c.Ctx.Input.IP())
+	trace.AddSession(sessionID, c.Input().Get("websiteId"), c.Ctx.Input.UserAgent(), c.Ctx.Input.IP())
 
-	c.Data["json"] = sessionId
+	c.Data["json"] = sessionID
 	c.ServeJSON()
 }
 
-func (c *ApiController) UploadTrace() {
+func (c *APIController) UploadTrace() {
 	var resp Response
 
-	websiteId := c.Input().Get("websiteId")
-	sessionId := c.StartSession().SessionID()
-	impressionId := c.Input().Get("impressionId")
+	websiteID := c.Input().Get("websiteId")
+	sessionID := c.StartSession().SessionID()
+	impressionID := c.Input().Get("impressionId")
 	userAgent := c.Ctx.Input.UserAgent()
-	clientIp := c.Ctx.Input.IP()
+	clientID := c.Ctx.Input.IP()
 
 	var data []byte
 	if c.Ctx.Request.Method == "GET" {
@@ -68,16 +68,16 @@ func (c *ApiController) UploadTrace() {
 		panic(err)
 	}
 
-	trace.AddSession(sessionId, websiteId, userAgent, clientIp)
-	trace.AddImpression(impressionId, sessionId, t.Path)
-	trace.AppendTraceToImpression(impressionId, &t)
+	trace.AddSession(sessionID, websiteID, userAgent, clientID)
+	trace.AddImpression(impressionID, sessionID, t.Path)
+	trace.AppendTraceToImpression(impressionID, &t)
 
 	// Only return traces for test page for visualization (websiteId == "mouselog")
-	if websiteId != "mouselog" {
+	if websiteID != "mouselog" {
 		resp = Response{Status: "ok", Msg: "", Data: ""}
 		if len(t.Events) == 0 {
 			resp.Msg = "config"
-			resp.Data = trace.ParseTrackConfig(trace.GetWebsite(websiteId).TrackConfig)
+			resp.Data = trace.ParseTrackConfig(trace.GetWebsite(websiteID).TrackConfig)
 		}
 
 		c.Data["json"] = resp
@@ -85,11 +85,11 @@ func (c *ApiController) UploadTrace() {
 		return
 	}
 
-	ss, _ := Session(sessionId)
+	ss, _ := Session(sessionID)
 	if len(t.Events) > 0 {
-		fmt.Printf("Read event [%s]: (%s, %f, %d, %d)\n", sessionId, t.Id, t.Events[0].Timestamp, t.Events[0].X, t.Events[0].Y)
+		fmt.Printf("Read event [%s]: (%s, %f, %d, %d)\n", sessionID, t.Id, t.Events[0].Timestamp, t.Events[0].X, t.Events[0].Y)
 	} else {
-		fmt.Printf("Read event [%s]: (%s, <empty>)\n", sessionId, t.Id)
+		fmt.Printf("Read event [%s]: (%s, <empty>)\n", sessionID, t.Id)
 	}
 
 	if len(t.Events) != 0 {
@@ -100,8 +100,8 @@ func (c *ApiController) UploadTrace() {
 	c.ServeJSON()
 }
 
-func (c *ApiController) ClearTrace() {
-	sessionId := c.StartSession().SessionID()
+func (c *APIController) ClearTrace() {
+	sessionID := c.StartSession().SessionID()
 	data := c.Ctx.Input.RequestBody
 
 	var t trace.Trace
@@ -110,7 +110,7 @@ func (c *ApiController) ClearTrace() {
 		panic(err)
 	}
 
-	ss, _ := Session(sessionId)
+	ss, _ := Session(sessionID)
 	if t2, ok := ss.TraceMap[t.Id]; ok {
 		delete(ss.TraceMap, t.Id)
 		for i, t3 := range ss.Traces {
@@ -120,7 +120,7 @@ func (c *ApiController) ClearTrace() {
 		}
 	}
 
-	fmt.Printf("Clear event [%s]: (%s, <empty>)\n", sessionId, t.Id)
+	fmt.Printf("Clear event [%s]: (%s, <empty>)\n", sessionID, t.Id)
 
 	c.Data["json"] = detect.GetDetectResult(ss, t.Id)
 	c.ServeJSON()

--- a/controllers/test.go
+++ b/controllers/test.go
@@ -31,7 +31,7 @@ func Session(sessionID string) (*trace.Session, bool) {
 	return sessions[sessionID], true
 }
 
-type Response struct {
+type response struct {
 	Status string      `json:"status"`
 	Msg    string      `json:"msg"`
 	Data   interface{} `json:"data"`
@@ -47,7 +47,7 @@ func (c *APIController) GetSessionID() {
 }
 
 func (c *APIController) UploadTrace() {
-	var resp Response
+	var resp response
 
 	websiteID := c.Input().Get("websiteId")
 	sessionID := c.StartSession().SessionID()
@@ -74,7 +74,7 @@ func (c *APIController) UploadTrace() {
 
 	// Only return traces for test page for visualization (websiteId == "mouselog")
 	if websiteID != "mouselog" {
-		resp = Response{Status: "ok", Msg: "", Data: ""}
+		resp = response{Status: "ok", Msg: "", Data: ""}
 		if len(t.Events) == 0 {
 			resp.Msg = "config"
 			resp.Data = trace.ParseTrackConfig(trace.GetWebsite(websiteID).TrackConfig)

--- a/controllers/test.go
+++ b/controllers/test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/astaxie/beego"
-
 	"github.com/microsoft/mouselog/detect"
 	"github.com/microsoft/mouselog/trace"
 )
@@ -14,36 +13,10 @@ type APIController struct {
 	beego.Controller
 }
 
-var sessions map[string]*trace.Session
-
-func init() {
-	sessions = map[string]*trace.Session{}
-}
-
-// Session either returns an already existing session or creates and returns a new one.
-// If a new session has been created, the returned boolean will be true.
-func Session(sessionID string) (*trace.Session, bool) {
-	if val, ok := sessions[sessionID]; ok {
-		return val, false
-	}
-
-	sessions[sessionID] = trace.NewSession(sessionID)
-	return sessions[sessionID], true
-}
-
 type response struct {
 	Status string      `json:"status"`
 	Msg    string      `json:"msg"`
 	Data   interface{} `json:"data"`
-}
-
-func (c *APIController) SessionID() {
-	sessionID := c.StartSession().SessionID()
-
-	trace.AddSession(sessionID, c.Input().Get("websiteId"), c.Ctx.Input.UserAgent(), c.Ctx.Input.IP())
-
-	c.Data["json"] = sessionID
-	c.ServeJSON()
 }
 
 func (c *APIController) UploadTrace() {

--- a/controllers/website.go
+++ b/controllers/website.go
@@ -6,19 +6,19 @@ import (
 	"github.com/microsoft/mouselog/trace"
 )
 
-func (c *ApiController) GetWebsites() {
+func (c *APIController) GetWebsites() {
 	c.Data["json"] = trace.GetWebsites()
 	c.ServeJSON()
 }
 
-func (c *ApiController) GetWebsite() {
+func (c *APIController) GetWebsite() {
 	id := c.Input().Get("id")
 
 	c.Data["json"] = trace.GetWebsite(id)
 	c.ServeJSON()
 }
 
-func (c *ApiController) UpdateWebsite() {
+func (c *APIController) UpdateWebsite() {
 	id := c.Input().Get("id")
 
 	var website trace.Website
@@ -31,7 +31,7 @@ func (c *ApiController) UpdateWebsite() {
 	c.ServeJSON()
 }
 
-func (c *ApiController) AddWebsite() {
+func (c *APIController) AddWebsite() {
 	var website trace.Website
 	err := json.Unmarshal(c.Ctx.Input.RequestBody, &website)
 	if err != nil {
@@ -42,7 +42,7 @@ func (c *ApiController) AddWebsite() {
 	c.ServeJSON()
 }
 
-func (c *ApiController) DeleteWebsite() {
+func (c *APIController) DeleteWebsite() {
 	id := c.Input().Get("id")
 
 	c.Data["json"] = trace.DeleteWebsite(id)

--- a/routers/router.go
+++ b/routers/router.go
@@ -19,7 +19,7 @@ func init() {
 	beego.Router("/api/upload-trace", &controllers.APIController{}, "GET:UploadTrace")
 
 	beego.Router("/api/clear-trace", &controllers.APIController{}, "POST:ClearTrace")
-	beego.Router("/api/get-session-id", &controllers.APIController{}, "GET:GetSessionId")
+	beego.Router("/api/get-session-id", &controllers.APIController{}, "GET:SessionID")
 
 	beego.Router("/api/list-sessions", &controllers.APIController{}, "GET:ListSessions")
 	beego.Router("/api/list-traces", &controllers.APIController{}, "GET:ListTraces")

--- a/routers/router.go
+++ b/routers/router.go
@@ -10,35 +10,35 @@ func init() {
 	ns :=
 		beego.NewNamespace("/api",
 			beego.NSInclude(
-				&controllers.ApiController{},
+				&controllers.APIController{},
 			),
 		)
 	beego.AddNamespace(ns)
 
-	beego.Router("/api/upload-trace", &controllers.ApiController{}, "POST:UploadTrace")
-	beego.Router("/api/upload-trace", &controllers.ApiController{}, "GET:UploadTrace")
+	beego.Router("/api/upload-trace", &controllers.APIController{}, "POST:UploadTrace")
+	beego.Router("/api/upload-trace", &controllers.APIController{}, "GET:UploadTrace")
 
-	beego.Router("/api/clear-trace", &controllers.ApiController{}, "POST:ClearTrace")
-	beego.Router("/api/get-session-id", &controllers.ApiController{}, "GET:GetSessionId")
+	beego.Router("/api/clear-trace", &controllers.APIController{}, "POST:ClearTrace")
+	beego.Router("/api/get-session-id", &controllers.APIController{}, "GET:GetSessionId")
 
-	beego.Router("/api/list-sessions", &controllers.ApiController{}, "GET:ListSessions")
-	beego.Router("/api/list-traces", &controllers.ApiController{}, "GET:ListTraces")
-	beego.Router("/api/get-trace", &controllers.ApiController{}, "GET:GetTrace")
+	beego.Router("/api/list-sessions", &controllers.APIController{}, "GET:ListSessions")
+	beego.Router("/api/list-traces", &controllers.APIController{}, "GET:ListTraces")
+	beego.Router("/api/get-trace", &controllers.APIController{}, "GET:GetTrace")
 
-	beego.Router("/api/list-rules", &controllers.ApiController{}, "GET:ListRules")
-	beego.Router("/api/upload-file", &controllers.ApiController{}, "POST:UploadFile")
+	beego.Router("/api/list-rules", &controllers.APIController{}, "GET:ListRules")
+	beego.Router("/api/upload-file", &controllers.APIController{}, "POST:UploadFile")
 
-	beego.Router("/api/get-websites", &controllers.ApiController{}, "GET:GetWebsites")
-	beego.Router("/api/get-website", &controllers.ApiController{}, "GET:GetWebsite")
-	beego.Router("/api/update-website", &controllers.ApiController{}, "POST:UpdateWebsite")
-	beego.Router("/api/add-website", &controllers.ApiController{}, "POST:AddWebsite")
-	beego.Router("/api/delete-website", &controllers.ApiController{}, "POST:DeleteWebsite")
+	beego.Router("/api/get-websites", &controllers.APIController{}, "GET:GetWebsites")
+	beego.Router("/api/get-website", &controllers.APIController{}, "GET:GetWebsite")
+	beego.Router("/api/update-website", &controllers.APIController{}, "POST:UpdateWebsite")
+	beego.Router("/api/add-website", &controllers.APIController{}, "POST:AddWebsite")
+	beego.Router("/api/delete-website", &controllers.APIController{}, "POST:DeleteWebsite")
 
-	beego.Router("/api/get-sessions", &controllers.ApiController{}, "GET:GetSessions")
-	beego.Router("/api/get-session", &controllers.ApiController{}, "GET:GetSession")
-	beego.Router("/api/delete-session", &controllers.ApiController{}, "POST:DeleteSession")
+	beego.Router("/api/get-sessions", &controllers.APIController{}, "GET:GetSessions")
+	beego.Router("/api/get-session", &controllers.APIController{}, "GET:GetSession")
+	beego.Router("/api/delete-session", &controllers.APIController{}, "POST:DeleteSession")
 
-	beego.Router("/api/get-impressions", &controllers.ApiController{}, "GET:GetImpressions")
-	beego.Router("/api/get-impression", &controllers.ApiController{}, "GET:GetImpression")
-	beego.Router("/api/delete-impression", &controllers.ApiController{}, "POST:DeleteImpression")
+	beego.Router("/api/get-impressions", &controllers.APIController{}, "GET:GetImpressions")
+	beego.Router("/api/get-impression", &controllers.APIController{}, "GET:GetImpression")
+	beego.Router("/api/delete-impression", &controllers.APIController{}, "POST:DeleteImpression")
 }

--- a/routers/router.go
+++ b/routers/router.go
@@ -10,18 +10,21 @@ func init() {
 	ns :=
 		beego.NewNamespace("/api",
 			beego.NSInclude(
+				&controllers.SessionController{},
 				&controllers.APIController{},
 			),
 		)
 	beego.AddNamespace(ns)
 
+	beego.Router("/api/get-session-id", &controllers.SessionController{}, "GET:SessionID")
+	beego.Router("/api/list-sessions", &controllers.SessionController{}, "GET:ListSessions")
+	beego.Router("/api/get-sessions", &controllers.SessionController{}, "GET:Sessions")
+	beego.Router("/api/get-session", &controllers.SessionController{}, "GET:Session")
+	beego.Router("/api/delete-session", &controllers.SessionController{}, "POST:DeleteSession")
+
 	beego.Router("/api/upload-trace", &controllers.APIController{}, "POST:UploadTrace")
 	beego.Router("/api/upload-trace", &controllers.APIController{}, "GET:UploadTrace")
-
 	beego.Router("/api/clear-trace", &controllers.APIController{}, "POST:ClearTrace")
-	beego.Router("/api/get-session-id", &controllers.APIController{}, "GET:SessionID")
-
-	beego.Router("/api/list-sessions", &controllers.APIController{}, "GET:ListSessions")
 	beego.Router("/api/list-traces", &controllers.APIController{}, "GET:ListTraces")
 	beego.Router("/api/get-trace", &controllers.APIController{}, "GET:GetTrace")
 
@@ -33,10 +36,6 @@ func init() {
 	beego.Router("/api/update-website", &controllers.APIController{}, "POST:UpdateWebsite")
 	beego.Router("/api/add-website", &controllers.APIController{}, "POST:AddWebsite")
 	beego.Router("/api/delete-website", &controllers.APIController{}, "POST:DeleteWebsite")
-
-	beego.Router("/api/get-sessions", &controllers.APIController{}, "GET:GetSessions")
-	beego.Router("/api/get-session", &controllers.APIController{}, "GET:GetSession")
-	beego.Router("/api/delete-session", &controllers.APIController{}, "POST:DeleteSession")
 
 	beego.Router("/api/get-impressions", &controllers.APIController{}, "GET:GetImpressions")
 	beego.Router("/api/get-impression", &controllers.APIController{}, "GET:GetImpression")


### PR DESCRIPTION
Hi,

I've changed some of the variable and functions names to be more idiomatic Go. I've also started splitting up the monolithic APIController into seperate, more descriptive ones, starting with the SessionController.

After refactoring the logic I'd like to change the URLs of those routes as well, "/api/get-sessions" isn't very RESTful I think.

But refactoring piece by piece makes sense, before looking into better, more descripting naming etc.

Regards