### PR TITLE
Optimizing the performance of loading table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ go.mod
 go.sum
 
 static/
+
+.vscode

--- a/controllers/session.go
+++ b/controllers/session.go
@@ -41,7 +41,7 @@ func (c *SessionController) SessionID() {
 }
 
 func (c *SessionController) Sessions() {
-	c.Data["json"] = trace.GetSessions(c.Input().Get("websiteId"))
+	c.Data["json"] = trace.GetSessions(c.Input().Get("websiteId"), util.ParseInt(c.Input().Get("resultCount")), util.ParseInt(c.Input().Get("offset")), c.Input().Get("sortField"), c.Input().Get("sortOrder"))
 	c.ServeJSON()
 }
 

--- a/trace/session.go
+++ b/trace/session.go
@@ -45,9 +45,18 @@ func countSessions(sessions []*Session) {
 	}
 }
 
-func GetSessions(websiteId string) []*Session {
+func GetSessions(websiteId string, resultCount int, offset int, sortField string, sortOrder string) []*Session {
 	sessions := []*Session{}
-	err := ormManager.engine.Where("website_id = ?", websiteId).Asc("created_time").Find(&sessions)
+	var err error
+	if sortField != "" {
+		if sortOrder == "1" {
+			err = ormManager.engine.Where("website_id = ?", websiteId).Asc(sortField).Limit(resultCount, offset).Find(&sessions)
+		} else {
+			err = ormManager.engine.Where("website_id = ?", websiteId).Desc(sortField).Limit(resultCount, offset).Find(&sessions)
+		}
+	} else {
+		err = ormManager.engine.Where("website_id = ?", websiteId).Asc("created_time").Limit(resultCount, offset).Find(&sessions)
+	}
 	if err != nil {
 		panic(err)
 	}

--- a/trace/website.go
+++ b/trace/website.go
@@ -16,13 +16,22 @@ type Website struct {
 
 func countWebsites(websites []*Website) {
 	for _, website := range websites {
-		sessionCount, err := ormManager.engine.Where("website_id = ?", website.Id).Count(&Session{})
-		if err != nil {
-			panic(err)
-		}
-
-		website.SessionCount = int(sessionCount)
+		countWebsiteSessions(website)
 	}
+}
+
+func countWebsiteSessions(website *Website) {
+	sessionCount, err := ormManager.engine.Where("website_id = ?", website.Id).Count(&Session{})
+	if err != nil {
+		panic(err)
+	}
+
+	website.SessionCount = int(sessionCount)
+	// TODO: Do we need to update `session_count` column?
+	// _, err := ormManager.engine.Id(website.Id).Cols("session_count").Update(website)
+	// if err != nil {
+	// 	panic(err)
+	// }
 }
 
 func GetWebsites() []*Website {
@@ -45,6 +54,7 @@ func GetWebsite(id string) *Website {
 	}
 
 	if existed {
+		countWebsiteSessions(&website)
 		return &website
 	} else {
 		return nil

--- a/web/src/SessionPage.js
+++ b/web/src/SessionPage.js
@@ -8,6 +8,7 @@ import {Button, Col, Popconfirm, Row, Table, Tooltip} from 'antd';
 import {EyeOutlined, MinusOutlined} from '@ant-design/icons';
 import * as Setting from "./Setting";
 import * as SessionBackend from "./backend/SessionBackend";
+import {getWebsite} from './backend/WebsiteBackend';
 import BreadcrumbBar from "./BreadcrumbBar";
 
 class SessionPage extends React.Component {
@@ -17,17 +18,23 @@ class SessionPage extends React.Component {
       classes: props,
       websiteId: props.match.params.websiteId,
       sessions: [],
-      loading: false,
+      loading: true,
       pagination: {
         current: 1,
         defaultCurrent: 1,
-        pageSize: 5,
-        total: 100
+        pageSize: 5
       }
     };
   }
 
   componentDidMount() {
+    let pager = {...this.state.pagination};
+    getWebsite(this.state.websiteId).then(res => {
+      pager.total = res.sessionCount;
+      this.setState({
+        pagination: pager
+      })
+    })
     this.getSessions(
       this.state.pagination.pageSize, 
       this.state.pagination.current,

--- a/web/src/backend/SessionBackend.js
+++ b/web/src/backend/SessionBackend.js
@@ -5,8 +5,19 @@
 
 import * as Setting from "../Setting";
 
-export function getSessions(websiteId) {
-  return fetch(`${Setting.ServerUrl}/api/get-sessions?websiteId=${websiteId}`, {
+function humpToLine(name) {
+  return name.replace(/([A-Z])/g,"_$1").toLowerCase();
+}
+
+export function getSessions(websiteId, resultCount, offset, sortField, sortOrder) {
+  let requestParams = [
+    `websiteId=${websiteId}`,
+    `resultCount=${resultCount}`,
+    `offset=${offset}`,
+    `sortField=${humpToLine(sortField)}`,
+    `sortOrder=${sortOrder}`
+  ].join('&');
+  return fetch(`${Setting.ServerUrl}/api/get-sessions?${requestParams}`, {
     method: "GET",
     credentials: "include"
   }).then(res => res.json());


### PR DESCRIPTION
Originally we loaded all sessions/impressions from the database when accessing a website/session. This costs a huge latency. I optimize the table in session page by loading small chunks of data dynamically according to the front-end table configuration. Every time a user accesses one page of data (like 10 sessions), it will automatically select and transmit the required data (the 10 sessions) from the server while ignoring the rest (other sessions). Table sorting functionality is still reserved.