### PR TITLE
api updates and dynamic data loading of impression table

### DIFF
--- a/controllers/impression.go
+++ b/controllers/impression.go
@@ -3,10 +3,12 @@
 
 package controllers
 
-import "github.com/microsoft/mouselog/trace"
-
+import (
+	"github.com/microsoft/mouselog/trace"
+	"github.com/microsoft/mouselog/util"
+)
 func (c *APIController) GetImpressions() {
-	c.Data["json"] = trace.GetImpressions(c.Input().Get("sessionId"))
+	c.Data["json"] = trace.GetImpressions(c.Input().Get("websiteId"), c.Input().Get("sessionId"), util.ParseInt(c.Input().Get("resultCount")), util.ParseInt(c.Input().Get("offset")), c.Input().Get("sortField"), c.Input().Get("sortOrder"))
 	c.ServeJSON()
 }
 

--- a/controllers/test.go
+++ b/controllers/test.go
@@ -45,7 +45,7 @@ func (c *APIController) UploadTrace() {
 	}
 
 	trace.AddSession(sessionID, websiteID, userAgent, clientID)
-	trace.AddImpression(impressionID, sessionID, t.Path)
+	trace.AddImpression(impressionID, sessionID, websiteID, t.Path)
 	trace.AppendTraceToImpression(impressionID, &t)
 
 	// Only return traces for test page for visualization (websiteId == "mouselog")

--- a/trace/impression.go
+++ b/trace/impression.go
@@ -8,6 +8,7 @@ import "strings"
 type Impression struct {
 	Id          string `xorm:"varchar(100) notnull pk" json:"id"`
 	SessionId   string `xorm:"varchar(100)" json:"sessionId"`
+	WebsiteId   string `xorm:"varchar(100)" json:"websiteId"`
 	CreatedTime string `xorm:"varchar(100)" json:"createdTime"`
 	UrlPath     string `xorm:"varchar(500)" json:"urlPath"`
 
@@ -66,8 +67,8 @@ func updateImpression(id string, impression *Impression) bool {
 	return true
 }
 
-func AddImpression(id string, sessionId string, urlPath string) bool {
-	s := Impression{Id: id, SessionId: sessionId, CreatedTime: getCurrentTime(), UrlPath: urlPath, Events: []Event{}}
+func AddImpression(id string, sessionId string, websiteId string, urlPath string) bool {
+	s := Impression{Id: id, SessionId: sessionId, WebsiteId: websiteId, CreatedTime: getCurrentTime(), UrlPath: urlPath, Events: []Event{}}
 	affected, err := ormManager.engine.Insert(s)
 	if err != nil && !strings.Contains(err.Error(), "Duplicate entry") {
 		panic(err)

--- a/trace/impression.go
+++ b/trace/impression.go
@@ -19,16 +19,6 @@ type Impression struct {
 	Events []Event `xorm:"mediumtext" json:"events"`
 }
 
-func getAllImpressions() []*Impression {
-	impressions := []*Impression{}
-	err := ormManager.engine.Cols("session_id").Find(&impressions)
-	if err != nil {
-		panic(err)
-	}
-
-	return impressions
-}
-
 func GetImpressions(websiteId string, sessionId string, resultCount int, offset int, sortField string, sortOrder string) []*Impression {
 	impressions := []*Impression{}
 	var err error

--- a/trace/impression.go
+++ b/trace/impression.go
@@ -29,9 +29,19 @@ func getAllImpressions() []*Impression {
 	return impressions
 }
 
-func GetImpressions(sessionId string) []*Impression {
+func GetImpressions(websiteId string, sessionId string, resultCount int, offset int, sortField string, sortOrder string) []*Impression {
 	impressions := []*Impression{}
-	err := ormManager.engine.Where("session_id = ?", sessionId).Asc("created_time").Find(&impressions)
+	var err error
+
+	if sortField != "" {
+		if sortOrder == "1" {
+			err = ormManager.engine.Where("session_id = ?", sessionId).And("website_id = ?", websiteId).Asc(sortField).Limit(resultCount, offset).Find(&impressions)
+		} else {
+			err = ormManager.engine.Where("session_id = ?", sessionId).And("website_id = ?", websiteId).Desc(sortField).Limit(resultCount, offset).Find(&impressions)
+		}
+	} else {
+		err = ormManager.engine.Where("session_id = ?", sessionId).And("website_id = ?", websiteId).Asc("created_time").Limit(resultCount, offset).Find(&impressions)
+	}
 	if err != nil {
 		panic(err)
 	}

--- a/web/src/ImpressionPage.js
+++ b/web/src/ImpressionPage.js
@@ -22,6 +22,7 @@ class ImpressionPage extends React.Component {
       sessionId: props.match.params.sessionId,
       impressions: [],
       website: null,
+      tableLoading: false
     };
   }
 
@@ -31,10 +32,14 @@ class ImpressionPage extends React.Component {
   }
 
   getImpressions() {
+    this.setState({
+      tableLoading: true
+    })
     ImpressionBackend.getImpressions(this.state.sessionId)
       .then((res) => {
           this.setState({
             impressions: res,
+            tableLoading: false
           });
         }
       );
@@ -167,7 +172,7 @@ class ImpressionPage extends React.Component {
 
     return (
       <div>
-        <Table columns={columns} dataSource={impressions} rowKey="name" size="middle" bordered pagination={{pageSize: 100}} />
+        <Table columns={columns} dataSource={impressions} rowKey="name" size="middle" bordered pagination={{pageSize: 100}} loading={this.state.tableLoading} />
       </div>
     );
   }

--- a/web/src/WebsitePage.js
+++ b/web/src/WebsitePage.js
@@ -15,6 +15,7 @@ class WebsitePage extends React.Component {
     this.state = {
       classes: props,
       websites: [],
+      tableLoading: false
     };
   }
 
@@ -23,13 +24,19 @@ class WebsitePage extends React.Component {
   }
 
   getWebsites() {
+    this.setState({
+      tableLoading: true
+    });
     WebsiteBackend.getWebsites()
       .then((res) => {
           this.setState({
             websites: res,
+            tableLoading: false
           });
         }
-      );
+      ).catch(err => {
+        console.log("Unable get websites info");
+      });
   }
 
   createConfig() {
@@ -205,7 +212,7 @@ class WebsitePage extends React.Component {
 
     return (
       <div>
-        <Table columns={columns} dataSource={websites} rowKey="name" size="middle" bordered pagination={{pageSize: 100}}
+        <Table columns={columns} dataSource={websites} rowKey="name" size="middle" bordered pagination={{pageSize: 100}} loading={this.state.tableLoading}
                title={() => (
                  <div>
                    My Websites&nbsp;&nbsp;&nbsp;&nbsp;

--- a/web/src/backend/ImpressionBackend.js
+++ b/web/src/backend/ImpressionBackend.js
@@ -4,9 +4,18 @@
  */
 
 import * as Setting from "../Setting";
+import {humpToLine} from "../utils";
 
-export function getImpressions(sessionId) {
-  return fetch(`${Setting.ServerUrl}/api/get-impressions?sessionId=${sessionId}`, {
+export function getImpressions(websiteId, sessionId, resultCount, offset, sortField, sortOrder) {
+  let requestParams = [
+    `websiteId=${websiteId}`,
+    `sessionId=${sessionId}`,
+    `resultCount=${resultCount}`,
+    `offset=${offset}`,
+    `sortField=${humpToLine(sortField)}`,
+    `sortOrder=${sortOrder}`
+  ].join('&');
+  return fetch(`${Setting.ServerUrl}/api/get-impressions?${requestParams}`, {
     method: "GET",
     credentials: "include"
   }).then(res => res.json());

--- a/web/src/backend/SessionBackend.js
+++ b/web/src/backend/SessionBackend.js
@@ -4,10 +4,7 @@
  */
 
 import * as Setting from "../Setting";
-
-function humpToLine(name) {
-  return name.replace(/([A-Z])/g,"_$1").toLowerCase();
-}
+import {humpToLine} from "../utils";
 
 export function getSessions(websiteId, resultCount, offset, sortField, sortOrder) {
   let requestParams = [

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -1,0 +1,3 @@
+export function humpToLine(name) {
+    return name.replace(/([A-Z])/g,"_$1").toLowerCase();
+}


### PR DESCRIPTION
1. Add loading state in website table and impression table
2. Refactor the `Impression` interface: add `WebsiteId`
3. Modify `/api/get-impressions`, it requires a 6-tuple parameter (`websiteId`, `sessionId`, `resultCount`, `offset`, `sortField`, `sortOrder`).
4. Refactor the code of counting impressions in `getSession(s)`.
5.  Dynamic data loading of impression table.