### PR TITLE
Detach the Get Started page from the server

### DIFF
--- a/web/src/App.js
+++ b/web/src/App.js
@@ -65,18 +65,10 @@ class App extends React.Component {
       this.setState({selectedMenuKey: 1});
     }
 
-    Backend.getSessionId(Setting.getWebsiteId())
-      .then(res => {
-        this.setState({
-          sessionId: res,
-          status: true
-        });
-      })
-      .catch(error => {
-        this.setState({
-          status: false
-        });
-      });
+    this.setState({
+      sessionId: Setting.getSessionId(),
+      status: true
+    });
   }
 
   onSwitchChange(checked, e) {

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -7,8 +7,21 @@ import React from "react";
 import {message, Tag} from "antd";
 import { v4 as uuid } from 'uuid';
 
+
+let isLocalStorageAvailable = (() => {
+  let testString = uuid();
+  try {
+      localStorage.setItem(testString, testString);
+      localStorage.removeItem(testString);
+      return true;
+  } catch(e) {
+      return false;
+  }
+})();
+
 export let ServerUrl = '';
 export let ImpressionId = uuid();
+let SessionId = '';
 
 export function initServerUrl() {
   const hostname = window.location.hostname;
@@ -26,6 +39,23 @@ export function getWebsiteId() {
 export function getImpressionId() {
   return ImpressionId;
 }
+
+export function getSessionId() {
+  if (SessionId) {
+    return SessionId;
+  }
+  if (!isLocalStorageAvailable) {
+      return "";
+  } 
+
+  let sessionId = localStorage.getItem('mouselogSessionID');
+  if (sessionId == null) {
+      sessionId = uuid();
+      localStorage.setItem('mouselogSessionID', sessionId);
+  }
+  return sessionId;
+}
+
 export function openLink(link) {
   const w = window.open('about:blank');
   w.location.href = link;

--- a/web/src/TestPage.js
+++ b/web/src/TestPage.js
@@ -164,14 +164,11 @@ class TestPage extends React.Component {
   }
 
   clearTrace() {
-    this.uploadTrace('clear');
-
     this.events = [];
     this.traces = [];
     this.trace = null;
 
     this.setState({
-      status: false,
       pageLoadTime: new Date(),
     });
   }

--- a/web/src/TestPage.js
+++ b/web/src/TestPage.js
@@ -64,6 +64,7 @@ class TestPage extends React.Component {
   componentDidMount() {
     Setting.setMouseHandler(this, this.mouseHandler);
 
+    // Update speed property every 0.1 s
     setInterval(() => {
       let eventBuckets = this.state.eventBuckets;
       eventBuckets = eventBuckets.slice(1);
@@ -75,19 +76,17 @@ class TestPage extends React.Component {
       })
     }, 100);
 
-    Backend.getSessionId(Setting.getWebsiteId())
-      .then(res => {
-        this.setState({
-          sessionId: res,
-          status: true
-        });
-        this.uploadTrace();
-      })
-      .catch(() => {
-        this.setState({
-          status: false
-        });
-      });
+    // Set the sessionId.
+    this.setState({
+      sessionId: Setting.getSessionId(),
+      status: true
+    })
+
+    // Load data here
+
+    this.setState({
+      onLoading: false
+    })
   }
 
   getByteCount(s) {
@@ -224,11 +223,11 @@ class TestPage extends React.Component {
       return;
     }
 
-    let x = e.pageX;
-    let y = e.pageY;
+    let x = parseInt(e.pageX);
+    let y = parseInt(e.pageY);
     if (x === undefined) {
-      x = e.changedTouches[0].pageX;
-      y = e.changedTouches[0].pageY;
+      x = parseInt(e.changedTouches[0].pageX);
+      y = parseInt(e.changedTouches[0].pageY);
     }
 
     let p = {
@@ -241,11 +240,6 @@ class TestPage extends React.Component {
     };
 
     this.events.push(p);
-
-    if (this.events.length === 50) {
-      this.uploadTrace();
-    }
-
     if (this.trace === null) {
       this.trace = this.newTrace();
     }


### PR DESCRIPTION
Now get-started page no longer upload data to the server. Trace data cache (/w localStorage) is not supported temporarily.